### PR TITLE
Fix problem detecting app migrations module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = "django-zillow-neighborhoods",
-    version = "0.8.0",
+    version = "0.8.1",
     author = "Clay McClure",
     author_email = "clay@daemons.net",
     url = 'https://github.com/claymation/django-zillow-neighborhoods',


### PR DESCRIPTION
This PR adds a `__init__.py` to the `migrations/` folder, so django can properly detect it during `manage.py migrate`.

Fixes #2 